### PR TITLE
Added centos-ci script for build and basic sanity test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build
+*.gz
+vendor

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,32 @@
-.PHONY: all glusterfs-csi-driver clean
+.PHONY: all glusterfs-csi-driver clean vendor-update vendor-install check-go check-reqs test
 
-all: glusterfs-csi-driver
+all: check-go check-reqs vendor-install glusterfs-csi-driver
 
-
-glusterfs-csi-driver:
-	if [ ! -d ./vendor ]; then dep ensure -vendor-only; fi
+csi-driver:
 	go build -o build/glusterfs-csi-driver  cmd/glusterfs/main.go
+
 clean:
 	go clean -r -x
 	rm -rf build
+
+check-go:
+	@./scripts/check-go.sh
+	@echo
+
+vendor-update:
+	@echo Updating vendored packages
+	@$(DEPENV) dep ensure -update -vendor-only
+	@echo
+
+vendor-install:
+	@echo Installing vendored packages
+	@$(DEPENV) dep ensure -vendor-only
+	@echo
+
+check-reqs:
+	@./scripts/check-reqs.sh
+	@echo
+
+test: check-reqs
+	@./test.sh $(TESTOPTIONS)
+	@echo

--- a/extras/centos-ci.sh
+++ b/extras/centos-ci.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# This script sets up the centos-ci environment and runs the PR tests for gluster-csi-driver.
+
+# if anything fails, we'll abort
+set -e
+
+REQ_GO_VERSION='1.9.4'
+# install Go
+if ! yum -y install "golang >= $REQ_GO_VERSION"
+then
+	# not the right version, install manually
+	# download URL comes from https://golang.org/dl/
+	curl -O https://storage.googleapis.com/golang/go${REQ_GO_VERSION}.linux-amd64.tar.gz
+	tar xzf go${REQ_GO_VERSION}.linux-amd64.tar.gz -C /usr/local
+	export PATH=$PATH:/usr/local/go/bin
+fi
+
+# also needs git, hg, bzr, svn gcc and make
+yum -y install git mercurial bzr subversion gcc make
+
+export CSISRC=$GOPATH/src/github.com/gluster/gluster-csi-driver
+cd "$CSISRC"
+
+# install the build and test requirements
+./scripts/install-reqs.sh
+
+# install vendored dependencies
+make vendor-install
+
+# verify build
+make csi-driver
+
+# run tests
+make test TESTOPTIONS=-v

--- a/scripts/check-go.sh
+++ b/scripts/check-go.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+REQ_GO_MAJOR_VERSION="1"
+REQ_GO_MINOR_VERSION="9"
+
+REQ_GO_VERSION="$REQ_GO_MAJOR_VERSION.$REQ_GO_MINOR_VERSION"
+
+missing() {
+  echo "Go$REQ_GO_VERSION or later is missing on this system."
+  echo "Install Go${REQ_GO_VERSION} using the preferred method for your system."
+  echo "Refer to https://golang.org/doc/install if Go$REQ_GO_VERSION is not available in the system repositories."
+
+  exit 1
+}
+
+check_go_version() {
+
+#Check if Go is installed
+INST_VERS_STR=$(go version) || missing
+
+INST_GO_VERSION=$(expr "$INST_VERS_STR" : ".*go version go\\([^ ]*\\) .*")
+INST_GO_MAJOR_VERSION=$(echo "$INST_GO_VERSION" | cut -d. -f1)
+INST_GO_MINOR_VERSION=$(echo "$INST_GO_VERSION" | cut -d. -f2)
+
+if [ "$REQ_GO_MAJOR_VERSION" -gt "$INST_GO_MAJOR_VERSION" ]; then
+        missing
+elif [ "$REQ_GO_MAJOR_VERSION" -eq "$INST_GO_MAJOR_VERSION" ] &&
+           [ "$REQ_GO_MINOR_VERSION" -gt "$INST_GO_MINOR_VERSION" ]; then
+        missing
+fi
+}
+
+check_go_version
+
+echo "Go$REQ_GO_VERSION or later is available on the system."

--- a/scripts/check-reqs.sh
+++ b/scripts/check-reqs.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Checks if the tools required for properly building, verifying and testing CSI driver are installed.
+
+TOOLS=(dep gometalinter)
+
+MISSING=0
+
+for tool in "${TOOLS[@]}"; do
+  type "$tool" >/dev/null 2>&1
+  if [ $? -ne 0 ]; then
+    echo "$tool package is missing on the system"
+    MISSING=1
+  else
+    echo "$tool package is available"
+  fi
+done
+
+if [ $MISSING -ne 0 ]; then
+  exit 1
+fi

--- a/scripts/install-reqs.sh
+++ b/scripts/install-reqs.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+GOPATH=$(go env GOPATH)
+GOBINDIR=$GOPATH/bin
+
+install_dep() {
+  DEPVER="v0.5.0"
+  DEPURL="https://github.com/golang/dep/releases/download/${DEPVER}/dep-linux-amd64"
+  type dep >/dev/null 2>&1
+  if [ $? -eq 0 ]; then
+    local version
+    version=$(dep version | awk '/^ version/{print $3}')
+    if [[ $version == "$DEPVER" || $version >  $DEPVER ]]; then
+      echo "dep ${DEPVER} or greater is already installed"
+      return
+    fi
+  fi
+
+  echo "Installing dep. Version: ${DEPVER}"
+  DEPBIN=$GOPATH/bin/dep
+  curl -L -o "$DEPBIN" $DEPURL
+  chmod +x "$DEPBIN"
+}
+
+install_gometalinter() {
+  LINTER_VER="2.0.5"
+  LINTER_TARBALL="gometalinter-${LINTER_VER}-linux-amd64.tar.gz"
+  LINTER_URL="https://github.com/alecthomas/gometalinter/releases/download/v${LINTER_VER}/${LINTER_TARBALL}"
+
+  type gometalinter >/dev/null 2>&1
+  if [ $? -eq 0 ]; then
+    echo "gometalinter already installed"
+    return
+  fi
+
+  echo "Installing gometalinter. Version: ${LINTER_VER}"
+  curl -L -o "$GOBINDIR/$LINTER_TARBALL" $LINTER_URL
+  tar -zxf "$GOBINDIR/$LINTER_TARBALL" --overwrite --strip-components 1 --exclude={COPYING,*.md} -C "$GOBINDIR"
+  rm -f "$GOBINDIR/$LINTER_TARBALL"
+}
+
+install_dep
+install_gometalinter

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+# main test runner
+# Executes all executable scripts under the test dir
+# in sorted order.
+
+FAILURES=()
+
+vecho () {
+	if [[ "${verbose}" = "yes" ]] ; then
+		echo "$*"
+	fi
+}
+
+run_test() {
+	cmd="${1}"
+	vecho "-- Running: ${tname} --"
+	"${cmd}"
+	sts=$?
+	if [[ ${sts} -ne 0 ]]; then
+		vecho "failed ${cmd} [${sts}]"
+		FAILURES+=("${cmd}")
+		if [[ "${exitfirst}" = "yes" ]]; then
+			exit 1
+		fi
+	fi
+}
+
+summary() {
+	if [[ ${#FAILURES[@]} -gt 0 ]]; then
+		echo "ERROR: failing tests:"
+		for i in "${!FAILURES[@]}"; do
+			echo "  ${FAILURES[i]}"
+		done
+		exit 1
+	else
+		echo "all tests passed"
+		exit 0
+	fi
+}
+
+show_help() {
+	echo "$0 [options]"
+	echo "  Options:"
+	echo "    -c|--coverage TYPE  Run tests with given coverage type"
+	echo "    -v|--verbose        Print verbose output"
+	echo "    -x|--exitfirst      Exit on first test failure"
+	echo "    -h|--help           Display help"
+	echo ""
+	echo "  Coverage Types:"
+	echo "    html -    Generate html files (one per package) in the"
+	echo "              coverage directory."
+	echo "    stdout -  Print coverage information to the console."
+	echo "    summary - Generate ONLY a packagecover.out to record"
+	echo "              coverage stats for all tests run.*"
+	echo "    * All modes generate the package cover information,"
+	echo "      summary mode disables all additional output."
+}
+
+CLI="$(getopt -o c:xvh --long coverage:,exitfirst,verbose,help -n "$0" -- "$@")"
+eval set -- "${CLI}"
+while true ; do
+	case "$1" in
+		-c|--coverage)
+			coverage="$2"
+			case ${coverage} in
+				stdout|html|summary);;
+				*)
+					echo "error: invalid coverage type ${coverage}."
+					echo "       need one of: stdout, html, summary"
+					exit 2
+				;;
+			esac
+			shift
+			shift
+		;;
+		-x|--exitfirst)
+			exitfirst=yes
+			shift
+		;;
+		-v|--verbose)
+			verbose=yes
+			shift
+		;;
+		-h|--help)
+			show_help
+			exit 0
+		;;
+		--)
+			shift
+			break
+		;;
+		*)
+			echo "unknown option" >&2
+			exit 2
+		;;
+	esac
+done
+
+trap summary EXIT
+
+SCRIPT_DIR="$(cd "$(dirname "${0}")" && pwd)"
+
+# environment vars exported for test scripts
+# (this way test scripts dont need cli parsing, we do it here)
+export CSI_TEST_EXITFIRST=${exitfirst}
+export CSI_TEST_SCRIPT_DIR="${SCRIPT_DIR}"
+export CSI_TEST_COVERAGE=${coverage}
+
+cd "${SCRIPT_DIR}" || exit 1
+for tname in $(ls test | sort) ; do
+	tpath="./test/${tname}"
+	if [[ ${tpath} =~ .*\.sh$ && -f ${tpath} && -x ${tpath} ]]; then
+		run_test "${tpath}"
+	fi
+done

--- a/test/001-testtest.sh
+++ b/test/001-testtest.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# This "test" exists merely to exercise the test "framework"
+
+if [ "$CSI_TEST_TEST" ]; then
+	exit "$CSI_TEST_TEST"
+fi
+exit 0

--- a/test/020-gofmt.sh
+++ b/test/020-gofmt.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# NOTE: This script needs be run from the root of the gluster-csi-driver repository
+
+# Find all Go source files in the repository, that are not vendored or generated
+# and then run gofmt on them
+
+RETVAL=0
+GENERATED_FILES="*(.pb|_string).go"
+
+for file in $(find . -path ./vendor -prune -o -type f -name '*.go' -print | grep -E -v "$GENERATED_FILES"); do
+	gofmt -s -l "$file"
+	if [[ $? -ne 0 ]]; then
+		echo -e "$file does not conform to gofmt rules. Run: gofmt -s -w $file"
+		RETVAL=1
+	fi
+done
+exit $RETVAL

--- a/test/020-golint.sh
+++ b/test/020-golint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# NOTE: This script needs be run from the root of the gluster-csi-driver repository
+
+# Find all Go source files in the repository, that are not vendored or generated
+# and then run golint on them
+
+# RETVAL=0
+# GENERATED_FILES="*(.pb|_string).go"
+
+# for file in $(find . -path ./vendor -prune -o -type f -name '*.go' -print | grep -E -v "$GENERATED_FILES"); do
+#   golint -set_exit_status "$file"
+#   if [[ $? -eq 1 ]]; then
+#     RETVAL=1
+#   fi
+# done
+# exit $RETVAL

--- a/test/020-gometalinter.sh
+++ b/test/020-gometalinter.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+gometalinter -D gotype -E gofmt --errors --deadline=5m -j 4 --vendor

--- a/test/020-test-makefiles.sh
+++ b/test/020-test-makefiles.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Check for Makefile syntax/style.
+# Currently only checks for consistent
+# use of tabs (instead of spaces) for indentation.
+
+SCRIPT_DIR="$(cd "$(dirname "${0}")" && pwd)"
+
+BASE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+FOUND=$(find "${BASE_DIR}" -name Makefile | \
+	grep -v ./vendor | \
+	xargs grep -n -E "^[[:space:]]* [[:space:]]*[^[:space:]]")
+
+if [[ -n "${FOUND}" ]]; then
+	echo "Found spaces in Makefiles:"
+	echo "${FOUND}"
+	exit 1
+fi
+
+exit 0

--- a/test/020-test-shellscripts.sh
+++ b/test/020-test-shellscripts.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Check for shell syntax & style.
+
+test_syntax() {
+	bash -n "${1}"
+}
+
+test_shellcheck() {
+	if [[ "${SHELLCHECK}" ]]; then
+		# only look for the "flag" on comment lines
+		# without this we can match our own code :-)
+		if grep -q '^#.*HEKETI-SKIP-SHELLCHECK' "${1}"; then
+			return 0
+		fi
+		# Note: Older shellcheck versions do not know '-x'.
+		#       Removing the use of -x for now.
+		shellcheck -e SC2181,SC2029,SC1091,SC1090,SC2012 "${1}"
+	else
+		return 0
+	fi
+}
+
+SHELLCHECK="$(which shellcheck 2>/dev/null)"
+
+SCRIPT_DIR="$(cd "$(dirname "${0}")" && pwd)"
+
+BASE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+if [[ -z "${SHELLCHECK}" ]]; then
+	echo "warning: could not find shellcheck ... will skip checks" >&2
+fi
+
+cd "${BASE_DIR}" || exit 2
+SCRIPTS=$(find . \( -path ./vendor -o -path ./.git -o -path ./build \) -prune \
+	-o -name '*.sh' -print | sort)
+
+failed=0
+for script in ${SCRIPTS}; do
+	err=0
+	test_syntax "${script}"
+	[[ $? -ne 0 ]] && err=1
+	test_shellcheck "${script}"
+	[[ $? -ne 0 ]] && err=1
+	((failed+=err))
+	if [[ ${err} -ne 0 && ${HEKETI_TEST_EXITFIRST} = "yes" ]]; then
+		echo "detected issues in ${script}" >&2
+		exit ${failed}
+	elif [[ ${err} -ne 0 ]]; then
+		echo "detected issues in ${script}" >&2
+	fi
+done
+exit ${failed}

--- a/test/030-govet.sh
+++ b/test/030-govet.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+GOPACKAGES="$(go list ./... | grep -v vendor)"
+# shellcheck disable=SC2086
+exec go vet ${GOPACKAGES}

--- a/test/100-gotest.sh
+++ b/test/100-gotest.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+GOPACKAGES="$(go list ./... | grep -v vendor | grep -v e2e)"
+# no special options, exec to go test w/ all pkgs
+if [[ ${CSI_TEST_EXITFIRST} != "yes" && -z ${CSI_TEST_COVERAGE} ]]; then
+	# shellcheck disable=SC2086
+	exec go test ${GOPACKAGES}
+fi
+
+# our options are set so we need to handle each go package one
+# at at time
+if [[ ${CSI_TEST_COVERAGE} ]]; then
+	GOTESTOPTS="-covermode=count -coverprofile=cover.out"
+	COVERFILE=packagecover.out
+	echo "mode: count" > "${COVERFILE}"
+fi
+
+failed=0
+for gopackage in ${GOPACKAGES}; do
+	echo "--- testing: ${gopackage} ---"
+	# shellcheck disable=SC2086
+	go test ${GOTESTOPTS} "${gopackage}"
+	[ $? -ne 0 ] && ((failed+=1))
+	if [[ -f cover.out ]]; then
+		# Append to coverfile
+		grep -v "^mode: count" cover.out >> "${COVERFILE}"
+	fi
+	if [[ ${CSI_TEST_COVERAGE} = "stdout" && -f cover.out ]]; then
+		go tool cover -func=cover.out
+	fi
+	if [[ ${CSI_TEST_COVERAGE} = "html" && -f cover.out ]]; then
+		mkdir -p coverage
+		fn="coverage/${gopackage////-}.html"
+		echo " * generating coverage html: ${fn}"
+		go tool cover -html=cover.out -o "${fn}"
+	fi
+	rm -f cover.out
+	if [[ ${failed} -ne 0 && ${CSI_TEST_EXITFIRST} = "yes" ]]; then
+		exit ${failed}
+	fi
+done
+exit ${failed}


### PR DESCRIPTION
Disabled golint for now because CSI spec expects some of the function
names which conflicts with `golint`

```
./pkg/glusterfs/nodeserver.go:121:23: method NodeGetId should be NodeGetID
```

All these tests CI is taken from `gluster/glusterd2`

Signed-off-by: Aravinda VK <avishwan@redhat.com>